### PR TITLE
Fix A/B test debugger toggle functionality and add status indicator

### DIFF
--- a/src/resources/views/debug.blade.php
+++ b/src/resources/views/debug.blade.php
@@ -10,12 +10,24 @@
 @endphp
 
 @if(config('app.debug'))
-<div id="ab-test-debug" style="position: fixed; bottom: 20px; right: 20px; background: linear-gradient(135deg, #1e293b 0%, #374151 100%); color: white; border-radius: 12px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 13px; z-index: 999999; box-shadow: 0 10px 40px rgba(0,0,0,0.4), 0 0 0 1px rgba(255,255,255,0.1); min-width: 320px; max-width: 400px; backdrop-filter: blur(10px); border: 1px solid rgba(255,255,255,0.1);">
-    <div style="display: flex; align-items: center; padding: 16px 20px 12px 20px; border-bottom: 1px solid rgba(255,255,255,0.1);">
-        <div style="width: 24px; height: 24px; background: linear-gradient(45deg, #10b981, #059669); border-radius: 6px; display: flex; align-items: center; justify-content: center; margin-right: 12px; font-size: 14px;">🧪</div>
-        <span style="font-weight: 600; font-size: 14px; color: #f8fafc;">A/B Testing Debugger</span>
-        <button onclick="toggleDebugger()" style="margin-left: auto; background: rgba(239, 68, 68, 0.1); border: none; color: #f87171; padding: 6px 8px; border-radius: 6px; cursor: pointer; font-size: 16px; line-height: 1; transition: all 0.2s; border: 1px solid rgba(239, 68, 68, 0.2);" onmouseover="this.style.background='rgba(239, 68, 68, 0.2)'" onmouseout="this.style.background='rgba(239, 68, 68, 0.1)'">×</button>
+<style>
+@keyframes blink {
+    0%, 50% { opacity: 1; }
+    51%, 100% { opacity: 0.3; }
+}
+</style>
+<div id="ab-test-debug-wrapper" style="position: fixed; bottom: 20px; right: 20px; z-index: 999999;">
+    <div id="ab-test-debug-collapsed" style="display: none; width: 40px; height: 40px; background: linear-gradient(135deg, #1e293b 0%, #374151 100%); border-radius: 50%; display: flex; align-items: center; justify-content: center; cursor: pointer; box-shadow: 0 4px 12px rgba(0,0,0,0.3); border: 1px solid rgba(255,255,255,0.1); position: relative;" onclick="toggleDebugger()">
+        <span style="font-size: 20px;">🐛</span>
+        <div style="position: absolute; top: 2px; right: 2px; width: 8px; height: 8px; border-radius: 50%; background: {{ empty($experiments) ? '#ef4444' : '#10b981' }}; animation: blink 1s infinite; box-shadow: 0 0 4px {{ empty($experiments) ? '#ef4444' : '#10b981' }};"></div>
     </div>
+    
+    <div id="ab-test-debug" style="background: linear-gradient(135deg, #1e293b 0%, #374151 100%); color: white; border-radius: 12px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 13px; box-shadow: 0 10px 40px rgba(0,0,0,0.4), 0 0 0 1px rgba(255,255,255,0.1); min-width: 320px; max-width: 400px; backdrop-filter: blur(10px); border: 1px solid rgba(255,255,255,0.1);">
+        <div style="display: flex; align-items: center; padding: 16px 20px 12px 20px; border-bottom: 1px solid rgba(255,255,255,0.1);">
+            <div style="width: 24px; height: 24px; background: linear-gradient(45deg, #10b981, #059669); border-radius: 6px; display: flex; align-items: center; justify-content: center; margin-right: 12px; font-size: 14px;">🧪</div>
+            <span style="font-weight: 600; font-size: 14px; color: #f8fafc;">A/B Testing Debugger</span>
+            <button onclick="toggleDebugger()" style="margin-left: auto; background: rgba(239, 68, 68, 0.1); border: none; color: #f87171; padding: 6px 8px; border-radius: 6px; cursor: pointer; font-size: 16px; line-height: 1; transition: all 0.2s; border: 1px solid rgba(239, 68, 68, 0.2);" onmouseover="this.style.background='rgba(239, 68, 68, 0.2)'" onmouseout="this.style.background='rgba(239, 68, 68, 0.1)'">×</button>
+        </div>
     
     <div style="padding: 16px 20px; max-height: 400px; overflow-y: auto;">
     
@@ -127,22 +139,30 @@
             </div>
         </div>
     @endif
+    </div>
 </div>
 
 <script>
-window.toggleDebugger = function() {
-    const debugger = document.getElementById('ab-test-debug');
-    const isCollapsed = debugger.style.height === '60px';
+// Define function immediately when script loads
+function toggleDebugger() {
+    const fullDebugger = document.getElementById('ab-test-debug');
+    const collapsedDebugger = document.getElementById('ab-test-debug-collapsed');
     
-    if (isCollapsed) {
-        debugger.style.height = 'auto';
-        debugger.style.maxHeight = '600px';
+    if (!fullDebugger || !collapsedDebugger) return;
+    
+    if (fullDebugger.style.display === 'none') {
+        // Show full debugger, hide caterpillar
+        fullDebugger.style.display = 'block';
+        collapsedDebugger.style.display = 'none';
     } else {
-        debugger.style.height = '60px';
-        debugger.style.maxHeight = '60px';
-        debugger.style.overflow = 'hidden';
+        // Hide full debugger, show caterpillar
+        fullDebugger.style.display = 'none';
+        collapsedDebugger.style.display = 'flex';
     }
-};
+}
+
+// Also assign to window for global access
+window.toggleDebugger = toggleDebugger;
 
 window.switchVariant = function(experiment, variant) {
     // Set override cookies for Laravel A/B tests

--- a/src/resources/views/debug.blade.php
+++ b/src/resources/views/debug.blade.php
@@ -17,7 +17,7 @@
 }
 </style>
 <div id="ab-test-debug-wrapper" style="position: fixed; bottom: 20px; right: 20px; z-index: 999999;">
-    <div id="ab-test-debug-collapsed" style="display: none; width: 40px; height: 40px; background: linear-gradient(135deg, #1e293b 0%, #374151 100%); border-radius: 50%; display: flex; align-items: center; justify-content: center; cursor: pointer; box-shadow: 0 4px 12px rgba(0,0,0,0.3); border: 1px solid rgba(255,255,255,0.1); position: relative;" onclick="toggleDebugger()">
+    <div id="ab-test-debug-collapsed" style="display: none; width: 40px; height: 40px; background: linear-gradient(135deg, #1e293b 0%, #374151 100%); border-radius: 50%; align-items: center; justify-content: center; cursor: pointer; box-shadow: 0 4px 12px rgba(0,0,0,0.3); border: 1px solid rgba(255,255,255,0.1); position: relative;" onclick="toggleDebugger()">
         <span style="font-size: 20px;">🐛</span>
         <div style="position: absolute; top: 2px; right: 2px; width: 8px; height: 8px; border-radius: 50%; background: {{ empty($experiments) ? '#ef4444' : '#10b981' }}; animation: blink 1s infinite; box-shadow: 0 0 4px {{ empty($experiments) ? '#ef4444' : '#10b981' }};"></div>
     </div>


### PR DESCRIPTION
- Fixed JavaScript error with reserved 'debugger' keyword
- Simplified toggle mechanism with separate collapsed/expanded elements
- Added visual status indicator (green/red blinking light) when collapsed
  - Green: Active A/B tests present
  - Red: No A/B tests running
- Changed collapsed view to caterpillar emoji (🐛) in circular button
- Improved UX with cleaner show/hide transitions

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a collapsible toggle for the debug panel, allowing users to minimise and expand the panel as needed.
  * Added a blinking status indicator to the collapsed icon, reflecting the presence of experiments.

* **Style**
  * Improved UI with a new animation for the status indicator in the collapsed state.

* **Refactor**
  * Streamlined the debug panel structure for better usability and visual clarity.
  * Enhanced toggle functionality for smoother switching between collapsed and expanded states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->