### PR TITLE
Exclude bots/crawlers from experiment assignment (fixes phantom lifts)

### DIFF
--- a/src/Services/AbTestService.php
+++ b/src/Services/AbTestService.php
@@ -60,6 +60,19 @@ class AbTestService
             }
         }
 
+        // Exclude bots/crawlers from NEW assignments. They render JS, hit the
+        // variant endpoint on page-load, get bucketed as 'desktop' by device
+        // detection (isRobot falls through isMobile/isTablet), and then never
+        // fire an event — inflating the population, skewing device mix to
+        // desktop, and diluting the control's conversion rate into a
+        // manufactured "lift". An existing (human) assignment above still wins;
+        // bots simply never enter ab_user_assignments.
+        if ($this->isBot()) {
+            $this->trackDebugExperiment($experimentName, 'control');
+
+            return 'control';
+        }
+
         $device = $this->detectDeviceType();
 
         // Device gating only applies to NEW users (no existing assignment above).
@@ -85,6 +98,29 @@ class AbTestService
      * Returns 'mobile' | 'tablet' | 'desktop', or null when no user-agent is present
      * (e.g. CLI / queue worker).
      */
+    /**
+     * True when the current request's user-agent is a known bot/crawler.
+     *
+     * Bots must never be ASSIGNED into an experiment — they load the page but
+     * never convert, so they only dilute the sample and skew the device mix.
+     * An empty user-agent (server-side call: CLI, queue, Stripe webhook tracking
+     * a real user's conversion) is NOT treated as a bot, so those paths keep
+     * resolving the user's existing assignment.
+     */
+    protected function isBot(): bool
+    {
+        $userAgent = $_SERVER['HTTP_USER_AGENT'] ?? null;
+
+        if (empty($userAgent)) {
+            return false;
+        }
+
+        $agent = new Agent;
+        $agent->setUserAgent($userAgent);
+
+        return $agent->isRobot();
+    }
+
     protected function detectDeviceType(): ?string
     {
         $userAgent = $_SERVER['HTTP_USER_AGENT'] ?? null;
@@ -198,6 +234,13 @@ class AbTestService
         $experiment = $this->getExperiment($experimentName);
 
         if (!$experiment || !$experiment->is_active) {
+            return 'control';
+        }
+
+        // Belt-and-braces: never record an assignment for a bot, even if this is
+        // reached outside variant() (the primary gate). Mirrors the early return
+        // there so ab_user_assignments only ever holds real, human traffic.
+        if ($this->isBot()) {
             return 'control';
         }
 

--- a/tests/Unit/AbTestServiceTest.php
+++ b/tests/Unit/AbTestServiceTest.php
@@ -48,6 +48,71 @@ class AbTestServiceTest extends TestCase
     }
 
     /** @test */
+    public function it_does_not_assign_bots_but_still_returns_control()
+    {
+        $experimentId = DB::table('ab_experiments')->insertGetId([
+            'name' => 'bot_test',
+            'variants' => json_encode(['control' => 50, 'variant_a' => 50]),
+            'is_active' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $originalUa = $_SERVER['HTTP_USER_AGENT'] ?? null;
+        $_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+
+        try {
+            $variant = $this->service->variant('bot_test', 'bot_user_1');
+
+            // A bot sees the page (control) but is NEVER recorded as a participant —
+            // otherwise event-less crawler loads dilute the sample and skew device mix.
+            $this->assertSame('control', $variant);
+            $this->assertDatabaseMissing('ab_user_assignments', [
+                'experiment_id' => $experimentId,
+                'user_id' => 'bot_user_1',
+            ]);
+        } finally {
+            if ($originalUa === null) {
+                unset($_SERVER['HTTP_USER_AGENT']);
+            } else {
+                $_SERVER['HTTP_USER_AGENT'] = $originalUa;
+            }
+        }
+    }
+
+    /** @test */
+    public function it_still_assigns_a_real_browser_user_agent()
+    {
+        $experimentId = DB::table('ab_experiments')->insertGetId([
+            'name' => 'human_test',
+            'variants' => json_encode(['control' => 50, 'variant_a' => 50]),
+            'is_active' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $originalUa = $_SERVER['HTTP_USER_AGENT'] ?? null;
+        $_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) '
+            .'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+
+        try {
+            $variant = $this->service->variant('human_test', 'human_user_1');
+
+            $this->assertContains($variant, ['control', 'variant_a']);
+            $this->assertDatabaseHas('ab_user_assignments', [
+                'experiment_id' => $experimentId,
+                'user_id' => 'human_user_1',
+            ]);
+        } finally {
+            if ($originalUa === null) {
+                unset($_SERVER['HTTP_USER_AGENT']);
+            } else {
+                $_SERVER['HTTP_USER_AGENT'] = $originalUa;
+            }
+        }
+    }
+
+    /** @test */
     public function it_returns_control_for_inactive_experiment()
     {
         DB::table('ab_experiments')->insert([


### PR DESCRIPTION
## Problem

Bots and crawlers were being assigned into experiments. They render JS, hit `/api/ab-testing/variant` on page-load, get bucketed as `desktop` by device detection (jenssegers/agent's `isRobot()` case falls through `isMobile`/`isTablet` to the `desktop` default), and then never fire an event.

The effect on results is severe: they inflate the participant count, skew the device mix to ~90% desktop, and — because they land disproportionately in whichever arm and never convert — dilute a control arm's conversion rate into a large **phantom "lift"** for every variant, computed over a tiny real sample.

This surfaced on `estate_agents_landing_v3`: 939 assignments in a few hours, **94.6% of them fired no event**, and a reported **+54.9% variant_b lift** that was an artifact of the event-less flood diluting the control — not a real effect.

## Fix

`variant()` and `assignVariant()` now short-circuit a bot user-agent to `control` **without recording an assignment**, mirroring the existing device-gate early return. So `ab_user_assignments` only ever holds real, human traffic; bots still see the page (control) but never enter the population.

- An **empty** user-agent (server-side conversion tracking — CLI, queue, Stripe webhook) is **not** treated as a bot, so those paths keep resolving a user's existing assignment.
- An existing (human) assignment still wins over the bot check, so nothing already recorded changes behaviour.
- Uses `jenssegers/agent`'s `isRobot()` (already a dependency).

Only affects **new** assignments going forward; historical bot rows remain and can be excluded in analysis.

## Tests

- A bot UA (Googlebot) returns `control` and is **not** written to `ab_user_assignments`.
- A real browser UA (mobile Safari) still gets assigned.

Full `AbTestServiceTest` is unchanged otherwise (the 3 pre-existing session/debug failures on `main` are untouched by this change).

## Note for owners
This is the code half. The estate-agents experiment's already-collected data is polluted by pre-fix bot assignments, so any lift computed before this deploys shouldn't be trusted — re-baseline after it's live. Related to SPC-074 (the gclid/source_url tracking gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved A/B test handling for automated or bot traffic.
  * Bot requests now receive the control experience without creating new test assignments.
  * Existing assignments remain valid.
  * Real browser visitors continue to receive and retain valid test variants.
  * Server-side requests with no user-agent continue to be handled as non-bot traffic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->